### PR TITLE
Missing multi-line commits

### DIFF
--- a/seed/vcs/git.py
+++ b/seed/vcs/git.py
@@ -41,7 +41,7 @@ class GitVcs(BaseVcs):
     def parse_log_messages(self, text):
         """Will parse git log messages in the 'short' format"""
         regex = r"commit ([0-9a-f]+)\nAuthor: (.*?)\n\n(.*?)(?:\n\n|$)"
-        messages = re.findall(regex, text)
+        messages = re.findall(regex, text, re.DOTALL)
         
         parsed = []
         for commit, author, message in messages:


### PR DESCRIPTION
Hey adam, hope the fb app is going well. I found that multi-line commits got ignored (the entire commit i mean) by the parse_log_messages regex, here is a quick 'catch-all' solution ;)
